### PR TITLE
Move postinstall to postbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-core-protocol",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Safe{Core} Protocol contracts",
   "main": "dist/deployments.js",
   "repository": {
@@ -29,7 +29,7 @@
     "lint:sol": "solhint 'contracts/**/*.sol'",
     "lint:ts": "eslint 'test/**/*.ts' --max-warnings 0 --fix",
     "typechain": "TS_NODE_TRANSPILE_ONLY=true yarn hardhat typechain",
-    "postinstall": "yarn typechain",
+    "postbuild": "yarn typechain",
     "deploy": "hardhat deploy --network",
     "prepack": "yarn build",
     "deploy-all": "hardhat deploy-contracts --network",


### PR DESCRIPTION
Fix error when using safe-core-protocol via npm, because `postinstall` is run to generate the types for the contracts, without hardhat or typechain being defined as dependencies.