### PR TITLE
Check if integration supports valid interfaceId

### DIFF
--- a/contracts/SafeProtocolRegistry.sol
+++ b/contracts/SafeProtocolRegistry.sol
@@ -4,6 +4,7 @@ import {ISafeProtocolRegistry} from "./interfaces/Registry.sol";
 import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {Enum} from "./common/Enum.sol";
+import {ISafeProtocolFunctionHandler, ISafeProtocolHooks, ISafeProtocolPlugin} from "./interfaces/Integrations.sol";
 
 contract SafeProtocolRegistry is ISafeProtocolRegistry, Ownable2Step {
     mapping(address => IntegrationInfo) public listedIntegrations;
@@ -16,6 +17,7 @@ contract SafeProtocolRegistry is ISafeProtocolRegistry, Ownable2Step {
 
     error CannotFlagIntegration(address integration);
     error CannotAddIntegration(address integration);
+    error IntegrationDoesNotSupportExpectedInterfaceId(address integration, bytes4 expectedInterfaceId);
 
     event IntegrationAdded(address integration);
     event IntegrationFlagged(address integration);
@@ -38,16 +40,33 @@ contract SafeProtocolRegistry is ISafeProtocolRegistry, Ownable2Step {
 
     /**
      * @notice Allows only owner to add a integration. A integration can be any address including zero address for now.
-     *         This function does not permit adding a integration twice.
-     *         TODO: Add logic to validate if integration implements correct interface.
+     *         This function does not permit adding a integration twice. This function validates if integration supports expected interfaceId.
      * @param integration Address of the integration
+     * @param integrationType Enum.IntegrationType indicating the type of integration
      */
-    function addIntegration(address integration, Enum.IntegrationType integrationType) external onlyOwner {
+    function addIntegration(address integration, Enum.IntegrationType integrationType) external virtual onlyOwner {
         IntegrationInfo memory integrationInfo = listedIntegrations[integration];
 
         if (integrationInfo.listedAt != 0) {
             revert CannotAddIntegration(integration);
         }
+
+        // Check if integration supports expected interface
+        if (
+            integrationType == Enum.IntegrationType.Hooks && !IERC165(integration).supportsInterface(type(ISafeProtocolHooks).interfaceId)
+        ) {
+            revert IntegrationDoesNotSupportExpectedInterfaceId(integration, type(ISafeProtocolHooks).interfaceId);
+        } else if (
+            integrationType == Enum.IntegrationType.Plugin && !IERC165(integration).supportsInterface(type(ISafeProtocolPlugin).interfaceId)
+        ) {
+            revert IntegrationDoesNotSupportExpectedInterfaceId(integration, type(ISafeProtocolPlugin).interfaceId);
+        } else if (
+            integrationType == Enum.IntegrationType.FunctionHandler &&
+            !IERC165(integration).supportsInterface(type(ISafeProtocolFunctionHandler).interfaceId)
+        ) {
+            revert IntegrationDoesNotSupportExpectedInterfaceId(integration, type(ISafeProtocolFunctionHandler).interfaceId);
+        }
+
         listedIntegrations[integration] = IntegrationInfo(uint64(block.timestamp), 0, integrationType);
         emit IntegrationAdded(integration);
     }

--- a/contracts/interfaces/Integrations.sol
+++ b/contracts/interfaces/Integrations.sol
@@ -9,7 +9,7 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
  * @notice In Safe{Core} Protocol, a function handler can be used to add additional functionality to a Safe.
  *         TODO: Add more explaination.
  */
-interface ISafeProtocolFunctionHandler {
+interface ISafeProtocolFunctionHandler is IERC165 {
     /**
      * @notice TODO: Add more explaination
      * @param safe A Safe instance
@@ -89,7 +89,7 @@ interface ISafeProtocolHooks is IERC165 {
 /**
  * @title ISafeProtocolPlugin - An interface that a Safe plugin should implement
  */
-interface ISafeProtocolPlugin {
+interface ISafeProtocolPlugin is IERC165 {
     /**
      * @notice A funtion that returns name of the plugin
      * @return name string name of the plugin

--- a/contracts/test/TestPlugin.sol
+++ b/contracts/test/TestPlugin.sol
@@ -16,6 +16,10 @@ abstract contract BaseTestPlugin is ISafeProtocolPlugin {
     function setRequiresRootAccess(bool _requiresRootAccess) external {
         requiresRootAccess = _requiresRootAccess;
     }
+
+    function supportsInterface(bytes4 interfaceId) external view override returns (bool) {
+        return interfaceId == type(ISafeProtocolPlugin).interfaceId || interfaceId == 0x01ffc9a7;
+    }
 }
 
 contract TestPlugin is BaseTestPlugin {

--- a/contracts/test/TestSafeProtocolRegistryUnrestricted.sol
+++ b/contracts/test/TestSafeProtocolRegistryUnrestricted.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.18;
-import {ISafeProtocolRegistry} from "../interfaces/Registry.sol";
-import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {Enum} from "../common/Enum.sol";
+
+import {SafeProtocolRegistry} from "../SafeProtocolRegistry.sol";
+import {ISafeProtocolFunctionHandler, ISafeProtocolHooks, ISafeProtocolPlugin} from "../interfaces/Integrations.sol";
 
 /**
  * @title This is a test version of SafeProtocolRegistry that does not restrict any account from adding Integrations.
@@ -11,75 +12,39 @@ import {Enum} from "../common/Enum.sol";
  *        The onlyOwner function modifier of `addIntegration(address,Enum.IntegrationType)` has been removed to allow
  *        developers to add any Integration to the resgistry.
  */
-contract TestSafeProtocolRegistryUnrestricted is ISafeProtocolRegistry, Ownable2Step {
-    mapping(address => IntegrationInfo) public listedIntegrations;
-
-    struct IntegrationInfo {
-        uint64 listedAt;
-        uint64 flaggedAt;
-        Enum.IntegrationType integrationType;
-    }
-
-    error CannotFlagIntegration(address integration);
-    error CannotAddIntegration(address integration);
-
-    event IntegrationAdded(address integration);
-    event IntegrationFlagged(address integration);
-
-    constructor(address initialOwner) {
-        _transferOwnership(initialOwner);
-    }
+contract TestSafeProtocolRegistryUnrestricted is SafeProtocolRegistry {
+    constructor(address initialOwner) SafeProtocolRegistry(initialOwner) {}
 
     /**
-     * @notice This function returns information about a integration
-     * @param integration Address of the integration to be checked
-     * @return listedAt Timestamp of listing the integration. This value will be 0 if not listed.
-     * @return flaggedAt Timestamp of falgging the integration. This value will be 0 if not flagged.
-     */
-    function check(address integration) external view returns (uint64 listedAt, uint64 flaggedAt) {
-        IntegrationInfo memory integrationInfo = listedIntegrations[integration];
-        listedAt = integrationInfo.listedAt;
-        flaggedAt = integrationInfo.flaggedAt;
-    }
-
-    /**
-     * @notice Allows only owner to add a integration. A integration can be any address including zero address for now.
-     *         This function does not permit adding a integration twice.
-     *         TODO: Add logic to validate if integration implements correct interface.
+     * @notice Allows any account to add a integration. A integration can be any address including zero address for now.
+     *         This function does not permit adding a integration twice. This function validates if integration supports expected interfaceId.
      * @param integration Address of the integration
+     * @param integrationType Enum.IntegrationType indicating the type of integration
      */
-    function addIntegration(address integration, Enum.IntegrationType integrationType) external {
+    function addIntegration(address integration, Enum.IntegrationType integrationType) external override {
         IntegrationInfo memory integrationInfo = listedIntegrations[integration];
 
         if (integrationInfo.listedAt != 0) {
             revert CannotAddIntegration(integration);
         }
-        listedIntegrations[integration] = IntegrationInfo(uint64(block.timestamp), 0, integrationType);
-        emit IntegrationAdded(integration);
-    }
 
-    /**
-     * @notice Allows only owner to flad a integration. Only previously added integration can be flagged.
-     *         This function does not permit flagging a integration twice.
-     *         A integration can be any address including zero address for now.
-     * @param integration Address of the integration
-     */
-    function flagIntegration(address integration) external onlyOwner {
-        IntegrationInfo memory integrationInfo = listedIntegrations[integration];
-
-        if (integrationInfo.listedAt == 0 || integrationInfo.flaggedAt != 0) {
-            revert CannotFlagIntegration(integration);
+        // Check if integration supports expected interface
+        if (
+            integrationType == Enum.IntegrationType.Hooks && !IERC165(integration).supportsInterface(type(ISafeProtocolHooks).interfaceId)
+        ) {
+            revert IntegrationDoesNotSupportExpectedInterfaceId(integration, type(ISafeProtocolHooks).interfaceId);
+        } else if (
+            integrationType == Enum.IntegrationType.Plugin && !IERC165(integration).supportsInterface(type(ISafeProtocolPlugin).interfaceId)
+        ) {
+            revert IntegrationDoesNotSupportExpectedInterfaceId(integration, type(ISafeProtocolPlugin).interfaceId);
+        } else if (
+            integrationType == Enum.IntegrationType.FunctionHandler &&
+            !IERC165(integration).supportsInterface(type(ISafeProtocolFunctionHandler).interfaceId)
+        ) {
+            revert IntegrationDoesNotSupportExpectedInterfaceId(integration, type(ISafeProtocolFunctionHandler).interfaceId);
         }
 
-        listedIntegrations[integration] = IntegrationInfo(
-            integrationInfo.listedAt,
-            uint64(block.timestamp),
-            integrationInfo.integrationType
-        );
-        emit IntegrationFlagged(integration);
-    }
-
-    function supportsInterface(bytes4 interfaceId) external view override returns (bool) {
-        return interfaceId == type(ISafeProtocolRegistry).interfaceId || interfaceId == type(IERC165).interfaceId;
+        listedIntegrations[integration] = IntegrationInfo(uint64(block.timestamp), 0, integrationType);
+        emit IntegrationAdded(integration);
     }
 }

--- a/test/utils/mockHooksBuilder.ts
+++ b/test/utils/mockHooksBuilder.ts
@@ -11,7 +11,7 @@ export const getHooksWithFailingPrechecks = async (): Promise<ISafeProtocolHooks
     return hre.ethers.getContractAt("ISafeProtocolHooks", await hooks.getAddress());
 };
 
-export const getHooksWithPassingPreChecks = async (): Promise<ISafeProtocolHooks> => {
+export const getHooksWithFailingPreChecks = async (): Promise<ISafeProtocolHooks> => {
     const hooks = await (await hre.ethers.getContractFactory("MockContract")).deploy();
     await hooks.givenMethodReturnBool("0x01ffc9a7", true);
     // 0x7359b742 -> selector for preCheckRootAccess


### PR DESCRIPTION
Fixes #16

Changes in PR:
- Check if integration implements valid interface id when adding to registry
- Inherit `SafeProtocolRegistry` in `TestSafeProtocolRegistryUnrestricted`
- Update docstrings
- Update tests