### PR TITLE
Bypass check for caller with root access

### DIFF
--- a/contracts/SafeProtocolManager.sol
+++ b/contracts/SafeProtocolManager.sol
@@ -93,7 +93,10 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
         for (uint256 i = 0; i < length; ++i) {
             SafeProtocolAction calldata safeProtocolAction = transaction.actions[i];
 
-            if (safeProtocolAction.to == address(this) || safeProtocolAction.to == safeAddress) {
+            if (
+                safeProtocolAction.to == address(this) ||
+                (safeProtocolAction.to == safeAddress && !enabledPlugins[safeAddress][msg.sender].rootAddressGranted)
+            ) {
                 revert InvalidToFieldInSafeProtocolAction(safeAddress, transaction.metadataHash, i);
             }
 

--- a/contracts/test/TestPlugin.sol
+++ b/contracts/test/TestPlugin.sol
@@ -32,12 +32,12 @@ contract TestPlugin is BaseTestPlugin {
     }
 }
 
-contract TestPluginWithRootAccess is BaseTestPlugin {
+contract TestPluginWithRootAccess is TestPlugin {
     constructor() {
         requiresRootAccess = true;
     }
 
-    function executeFromPlugin(
+    function executeRootAccessTxFromPlugin(
         ISafeProtocolManager manager,
         ISafe safe,
         SafeRootAccess calldata safeRootAccesstx


### PR DESCRIPTION
Fixes #62 

- Allow caller to send transaction to `safe` if root access it granted.