### PR TITLE
Optimize SafeProtocolManager codesize

### DIFF
--- a/contracts/SafeProtocolManager.sol
+++ b/contracts/SafeProtocolManager.sol
@@ -49,16 +49,12 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
     error InvalidToFieldInSafeProtocolAction(address safe, bytes32 metadataHash, uint256 index);
 
     modifier onlyEnabledPlugin(address safe) {
-        if (enabledPlugins[safe][msg.sender].nextPluginPointer == address(0)) {
-            revert PluginNotEnabled(msg.sender);
-        }
+        checkOnlyEnabledPlugin(safe);
         _;
     }
 
     modifier noZeroOrSentinelPlugin(address plugin) {
-        if (plugin == address(0) || plugin == SENTINEL_MODULES) {
-            revert InvalidPluginAddress(plugin);
-        }
+        checkNoZeroOrSentinelPlugin(plugin);
         _;
     }
 
@@ -426,5 +422,17 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
             interfaceId == 0xe6d7a83a || // type(Guard).interfaceId without Module Guard (required for backward compatibility for Safe v1.4 and below)
             interfaceId == type(ISafeProtocolManager).interfaceId ||
             interfaceId == type(IERC165).interfaceId; // 0x01ffc9a7
+    }
+
+    function checkOnlyEnabledPlugin(address safe) private view {
+        if (enabledPlugins[safe][msg.sender].nextPluginPointer == address(0)) {
+            revert PluginNotEnabled(msg.sender);
+        }
+    }
+
+    function checkNoZeroOrSentinelPlugin(address plugin) private pure {
+        if (plugin == address(0) || plugin == SENTINEL_MODULES) {
+            revert InvalidPluginAddress(plugin);
+        }
     }
 }


### PR DESCRIPTION
Fixes: #81 
Changes in PR:
Create private functions in `SafeProtocolManager.sol`

In current main branch codesize exceeds by few bytes for SafeProtocolManager
```
SafeProtocolManager 24584 bytes (limit is 24576)
TestSafeProtocolManager 24631 bytes (limit is 24576)
```
After changes in PR:
```
SafeProtocolManager 22846 bytes (limit is 24576)
TestSafeProtocolManager 22893 bytes (limit is 24576)
```