### PR TITLE
Rename error AccountDoesNotImplementValidInterfaceId to ContractDoesNotImplementValidInterfaceId

### DIFF
--- a/contracts/SafeProtocolManager.sol
+++ b/contracts/SafeProtocolManager.sol
@@ -179,7 +179,7 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
         // address(0) check omitted because it is not expected to enable it as a plugin and
         // call to it would fail. Additionally, registry should not permit address(0) as an module.
         if (!ISafeProtocolPlugin(plugin).supportsInterface(type(ISafeProtocolPlugin).interfaceId))
-            revert AccountDoesNotImplementValidInterfaceId(plugin);
+            revert ContractDoesNotImplementValidInterfaceId(plugin);
 
         PluginAccessInfo storage senderSentinelPlugin = enabledPlugins[msg.sender][SENTINEL_MODULES];
         PluginAccessInfo storage senderPlugin = enabledPlugins[msg.sender][plugin];

--- a/contracts/base/FunctionHandlerManager.sol
+++ b/contracts/base/FunctionHandlerManager.sol
@@ -43,7 +43,7 @@ abstract contract FunctionHandlerManager is RegistryManager, OnlyAccountCallable
         if (functionHandler != address(0)) {
             checkPermittedModule(functionHandler);
             if (!ISafeProtocolFunctionHandler(functionHandler).supportsInterface(type(ISafeProtocolFunctionHandler).interfaceId))
-                revert AccountDoesNotImplementValidInterfaceId(functionHandler);
+                revert ContractDoesNotImplementValidInterfaceId(functionHandler);
         }
 
         // No need to check if functionHandler implements expected interfaceId as check will be done when adding to registry.

--- a/contracts/base/HooksManager.sol
+++ b/contracts/base/HooksManager.sol
@@ -38,7 +38,7 @@ abstract contract HooksManager is RegistryManager, OnlyAccountCallable {
         if (hooks != address(0)) {
             checkPermittedModule(hooks);
             if (!ISafeProtocolHooks(hooks).supportsInterface(type(ISafeProtocolHooks).interfaceId))
-                revert AccountDoesNotImplementValidInterfaceId(hooks);
+                revert ContractDoesNotImplementValidInterfaceId(hooks);
         }
         enabledHooks[msg.sender] = hooks;
         emit HooksChanged(msg.sender, hooks);

--- a/contracts/base/RegistryManager.sol
+++ b/contracts/base/RegistryManager.sol
@@ -10,7 +10,7 @@ contract RegistryManager is Ownable2Step {
     event RegistryChanged(address indexed oldRegistry, address indexed newRegistry);
 
     error ModuleNotPermitted(address plugin, uint64 listedAt, uint64 flaggedAt);
-    error AccountDoesNotImplementValidInterfaceId(address account);
+    error ContractDoesNotImplementValidInterfaceId(address account);
 
     modifier onlyPermittedModule(address module) {
         checkPermittedModule(module);
@@ -28,7 +28,7 @@ contract RegistryManager is Ownable2Step {
     constructor(address _registry, address intitalOwner) {
         _transferOwnership(intitalOwner);
         if (!IERC165(_registry).supportsInterface(type(ISafeProtocolRegistry).interfaceId)) {
-            revert AccountDoesNotImplementValidInterfaceId(_registry);
+            revert ContractDoesNotImplementValidInterfaceId(_registry);
         }
         registry = _registry;
     }
@@ -52,7 +52,7 @@ contract RegistryManager is Ownable2Step {
      */
     function setRegistry(address newRegistry) external onlyOwner {
         if (!IERC165(newRegistry).supportsInterface(type(ISafeProtocolRegistry).interfaceId)) {
-            revert AccountDoesNotImplementValidInterfaceId(newRegistry);
+            revert ContractDoesNotImplementValidInterfaceId(newRegistry);
         }
         emit RegistryChanged(registry, newRegistry);
         registry = newRegistry;

--- a/test/FunctionHandlerManager.spec.ts
+++ b/test/FunctionHandlerManager.spec.ts
@@ -168,7 +168,7 @@ describe("FunctionHandler", async () => {
         ]);
 
         await expect(safe.executeCallViaMock(safe.target, 0n, dataSetFunctionHandler, MaxUint256))
-            .to.be.revertedWithCustomError(functionHandlerManager, "AccountDoesNotImplementValidInterfaceId")
+            .to.be.revertedWithCustomError(functionHandlerManager, "ContractDoesNotImplementValidInterfaceId")
             .withArgs(mockFunctionHandler.target);
     });
 

--- a/test/SafeProtocolManager.spec.ts
+++ b/test/SafeProtocolManager.spec.ts
@@ -105,7 +105,7 @@ describe("SafeProtocolManager", async () => {
                 await mockPlugin.givenMethodReturnBool("0x01ffc9a7", false);
                 const data = safeProtocolManager.interface.encodeFunctionData("enablePlugin", [mockPlugin.target, false]);
                 await expect(safe.exec(safe.target, 0, data))
-                    .to.be.revertedWithCustomError(safeProtocolManager, "AccountDoesNotImplementValidInterfaceId")
+                    .to.be.revertedWithCustomError(safeProtocolManager, "ContractDoesNotImplementValidInterfaceId")
                     .withArgs(mockPlugin.target);
             });
 

--- a/test/base/HooksManager.spec.ts
+++ b/test/base/HooksManager.spec.ts
@@ -67,7 +67,7 @@ describe("HooksManager", async () => {
         await expect(hooksManager.setHooks(hooksAddress)).to.be.reverted;
     });
 
-    it("Should revert AccountDoesNotImplementValidInterfaceId if user attempts address does not implement Hooks interface", async () => {
+    it("Should revert ContractDoesNotImplementValidInterfaceId if user attempts address does not implement Hooks interface", async () => {
         const { hooksManager, safe, safeProtocolRegistry } = await setupTests();
         const contractNotImplementingHooksInterface = await (await hre.ethers.getContractFactory("MockContract")).deploy();
         await contractNotImplementingHooksInterface.givenMethodReturnBool("0x01ffc9a7", true);
@@ -77,7 +77,7 @@ describe("HooksManager", async () => {
         const calldata = hooksManager.interface.encodeFunctionData("setHooks", [contractNotImplementingHooksInterface.target]);
         await expect(safe.exec(safe.target, 0n, calldata)).to.be.revertedWithCustomError(
             hooksManager,
-            "AccountDoesNotImplementValidInterfaceId",
+            "ContractDoesNotImplementValidInterfaceId",
         );
     });
 });

--- a/test/base/RegistryManager.spec.ts
+++ b/test/base/RegistryManager.spec.ts
@@ -32,11 +32,11 @@ describe("RegistryManager", async () => {
         const registry = await getMockRegistryWithInvalidInterfaceSupport();
         await expect(registryManager.connect(owner).setRegistry(await registry.getAddress())).to.be.revertedWithCustomError(
             registryManager,
-            "AccountDoesNotImplementValidInterfaceId",
+            "ContractDoesNotImplementValidInterfaceId",
         );
     });
 
-    it("Should revert with AccountDoesNotImplementValidInterfaceId when creating registry manager with registry not supporting valid interfaceId", async () => {
+    it("Should revert with ContractDoesNotImplementValidInterfaceId when creating registry manager with registry not supporting valid interfaceId", async () => {
         const registry = await getMockRegistryWithInvalidInterfaceSupport();
         await expect(hre.ethers.deployContract("RegistryManager", [await registry.getAddress(), owner.address], { signer: deployer })).to.be
             .reverted;


### PR DESCRIPTION
Fixes #78 

Changes in PR
- Rename error `AccountDoesNotImplementValidInterfaceId` to `ContractDoesNotImplementValidInterfaceId`
- Update relevant tests